### PR TITLE
ports: fix cortexm0 linker script

### DIFF
--- a/common/ports/ARMCMx/compilers/GCC/rules_code_cortexm0.ld
+++ b/common/ports/ARMCMx/compilers/GCC/rules_code_cortexm0.ld
@@ -39,7 +39,7 @@ SECTIONS
         __fini_array_end = .;
     } > XTORS_FLASH AT > XTORS_FLASH_LMA
 
-    .initcall ALIGN(16)
+    .initcall : ALIGN(16)
     {
         __module_initcall_start = .;
         KEEP(*(SORT(.initcall.*)))


### PR DESCRIPTION
Fixes the following error:

`/arm-none-eabi/bin/ld:rules_code_cortexm0.ld:43: syntax error`